### PR TITLE
Fix/react docgen typescript crash

### DIFF
--- a/.changeset/gorgeous-spiders-tell.md
+++ b/.changeset/gorgeous-spiders-tell.md
@@ -1,0 +1,6 @@
+---
+"design-system": patch
+"@lighting-beetle/lighter-styleguide": patch
+---
+
+Props will handle component without `__docgenInfo`

--- a/.changeset/lazy-planes-change.md
+++ b/.changeset/lazy-planes-change.md
@@ -1,0 +1,5 @@
+---
+"@lighting-beetle/next-lighter-config": patch
+---
+
+disable react-docgen-typescript-loader

--- a/packages/design-system/src/utils/getMDXScope.ts
+++ b/packages/design-system/src/utils/getMDXScope.ts
@@ -3,13 +3,13 @@ import { Button, Icon, Select } from "components";
 export default function getMDXScope() {
   return {
     // TODO: We should not name all possible components here
-    button: { __docgenInfo: Button.__docgenInfo },
-    select: { __docgenInfo: Select.__docgenInfo },
-    icon: { __docgenInfo: Icon.__docgenInfo },
+    button: { __docgenInfo: Button.__docgenInfo ?? null },
+    select: { __docgenInfo: Select.__docgenInfo ?? null },
+    icon: { __docgenInfo: Icon.__docgenInfo ?? null },
     selectItems: [
       { label: "Item 1", value: "item 1" },
       { label: "Item 2", value: "item 2" },
-      { label: "Item 3", value: "item 3" }
-    ]
+      { label: "Item 3", value: "item 3" },
+    ],
   };
 }

--- a/packages/lighter-styleguide/src/components/Props/PropsTable.tsx
+++ b/packages/lighter-styleguide/src/components/Props/PropsTable.tsx
@@ -13,7 +13,7 @@ ComponentName.defaultProps = {
 };
 
 const PropsTable = () => {
-  const { displayName, props } = usePropsContext();
+  const { displayName, props = {} } = usePropsContext();
 
   const data = useMemo(() => Object.keys(props).map((key) => props[key]), [
     props,

--- a/packages/lighter-styleguide/src/components/Props/useProps.ts
+++ b/packages/lighter-styleguide/src/components/Props/useProps.ts
@@ -28,7 +28,7 @@ const useProps = ({ component }: UseProps): DocgenInfo => {
   return {
     displayName: info?.displayName,
     description: info?.description,
-    props: info?.props,
+    props: info?.props ?? {},
   };
 };
 

--- a/packages/next-lighter-config/index.js
+++ b/packages/next-lighter-config/index.js
@@ -1,4 +1,4 @@
-const path = require("path");
+// const path = require("path");
 const withPlugins = require("next-compose-plugins");
 const mdx = require("@next/mdx");
 const css = require("@zeit/next-css");
@@ -12,7 +12,7 @@ const noFS = () => (nextConfig = {}) => {
     webpack(config, options) {
       if (!options.isServer) {
         config.node = {
-          fs: "empty"
+          fs: "empty",
         };
       }
       if (typeof nextConfig.webpack === "function") {
@@ -20,7 +20,7 @@ const noFS = () => (nextConfig = {}) => {
       }
 
       return config;
-    }
+    },
   });
 };
 
@@ -43,7 +43,7 @@ const staticEntries = ({ entriesMap }) => (nextConfig = {}) => {
         // custom build manifest file, because next.js build-manifest.json don't contains 'static' entry and we need to know entry hash in production
         config.plugins.unshift(
           new CustomEntriesBuildManifestPlugin({
-            entries: Object.keys(entriesMap)
+            entries: Object.keys(entriesMap),
           })
         );
       }
@@ -53,47 +53,50 @@ const staticEntries = ({ entriesMap }) => (nextConfig = {}) => {
       }
 
       return config;
-    }
+    },
   });
 };
 
-const reactDocgenTypescript = ({
-  tsConfigPath = path.resolve(__dirname, "..", "..", "tsconfig.json"),
-  componentsPath = path.resolve(__dirname, "..", "components")
-}) => (nextConfig = {}) => {
-  return Object.assign({}, nextConfig, {
-    webpack(config, options) {
-      config.module.rules.push({
-        test: /\.tsx?$/,
-        include: componentsPath,
-        use: [
-          options.defaultLoaders.babel,
-          {
-            loader: require.resolve("react-docgen-typescript-loader"),
-            options: {
-              // Provide the path to your tsconfig.json so that your stories can
-              // display types from outside each individual story.
-              tsconfigPath: tsConfigPath,
-              // Filter types from node_modules, because we don't want to display them in documentation by default
-              propFilter: props =>
-                !(
-                  props.parent && props.parent.fileName.includes("node_modules")
-                )
-            }
-          }
-        ]
-      });
+// FIXME: This loader is not supported anymore and it was causeing memory leaks and crashing node. https://github.com/storybookjs/babel-plugin-react-docgen could be option for replacing this, but I couldn't make it work.
+// const reactDocgenTypescript = ({
+//   tsConfigPath = path.resolve(__dirname, "..", "..", "tsconfig.json"),
+//   componentsPath = path.resolve(__dirname, "..", "components")
+// }) => (nextConfig = {}) => {
+//   return Object.assign({}, nextConfig, {
+//     webpack(config, options) {
+//       config.module.rules.push({
+//         test: /\.tsx?$/,
+//         include: componentsPath,
+//         use: [
+//           options.defaultLoaders.babel,
+//           {
+//             loader: require.resolve("react-docgen-typescript-loader"),
+//             options: {
+//               // Provide the path to your tsconfig.json so that your stories can
+//               // display types from outside each individual story.
+//               tsconfigPath: tsConfigPath,
+//               // Filter types from node_modules, because we don't want to display them in documentation by default
+//               propFilter: props =>
+//                 !(
+//                   props.parent && props.parent.fileName.includes("node_modules")
+//                 )
+//             }
+//           }
+//         ]
+//       });
 
-      if (typeof nextConfig.webpack === "function") {
-        return nextConfig.webpack(config, options);
-      }
+//       if (typeof nextConfig.webpack === "function") {
+//         return nextConfig.webpack(config, options);
+//       }
 
-      return config;
-    }
-  });
-};
+//       return config;
+//     }
+//   });
+// };
 
-module.exports = ({ tsConfigPath, componentsPath, staticEntriesMap } = {}) =>
+module.exports = ({
+  /* tsConfigPath, componentsPath, */ staticEntriesMap,
+} = {}) =>
   withPlugins(
     [
       sass,
@@ -102,15 +105,15 @@ module.exports = ({ tsConfigPath, componentsPath, staticEntriesMap } = {}) =>
         mdx({
           extension: /\.mdx?$/,
           options: {
-            remarkPlugins: [frontMatterToMDXRemarkPlugin]
-          }
-        })
+            remarkPlugins: [frontMatterToMDXRemarkPlugin],
+          },
+        }),
       ],
       staticEntries({ entriesMap: staticEntriesMap }),
-      reactDocgenTypescript({ tsConfigPath, componentsPath }),
-      noFS()
+      // reactDocgenTypescript({ tsConfigPath, componentsPath }),
+      noFS(),
     ],
     {
-      pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"]
+      pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
     }
   );


### PR DESCRIPTION
Vypol som `react-docgen-typescript-loader`, lebo sposoboval memory leak a crashoval proces. Cize akutalne sa nebude zobrazoat dokumentacia propsov.

cc @DushanT 