### PR TITLE
Feat/show react docgen in design system

### DIFF
--- a/.changeset/curvy-clocks-repair.md
+++ b/.changeset/curvy-clocks-repair.md
@@ -1,0 +1,6 @@
+---
+"design-system": minor
+"components": patch
+---
+
+Display component props documentation in Design System page with `<PropsTable />`

--- a/.changeset/hot-cycles-trade.md
+++ b/.changeset/hot-cycles-trade.md
@@ -1,0 +1,5 @@
+---
+"@lighting-beetle/lighter-styleguide": minor
+---
+
+enhance PropsTable type column value based on type type

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ComponentProps } from "react";
 import cx from "classnames";
 // import "./styles/style.scss";
 
@@ -17,7 +17,7 @@ type ButtonProps = {
   variant?: "plain";
   /** Purpose of the button. Default means CTA button. */
   purpose?: "secondary" | "link";
-} & (React.ComponentProps<"button"> | React.ComponentProps<"a">);
+} & (ComponentProps<"button"> | ComponentProps<"a">);
 
 export const Button = ({
   className,

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { ComponentProps } from "react";
 import cx from "classnames";
 
-type CardProps = JSX.IntrinsicElements["div"];
+type CardProps = ComponentProps<"div">;
 
 const CLASS_ROOT = "card";
 

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -21,7 +21,8 @@
     "netlify-cms-widget-mdx": "~0.4.4",
     "next": "~11.1.2",
     "next-compose-plugins": "~2.2.1",
-    "next-transpile-modules": "~8.0.0"
+    "next-transpile-modules": "~8.0.0",
+    "react-docgen-typescript": "^2.2.2"
   },
   "browserslist": ">1%, not ie 11, not op_mini all"
 }

--- a/packages/design-system/src/pages/components/[slug].tsx
+++ b/packages/design-system/src/pages/components/[slug].tsx
@@ -8,6 +8,7 @@ import { getMDXComponent } from "mdx-bundler/client";
 import DesignSystemPage from "../../components/DesignSystemPage";
 import { getDesignSystemRoutes } from "../../utils";
 import { mdxComponents } from "@lighting-beetle/lighter-styleguide";
+import esbuildReactDocgenTypescriptPlugin from "../../utils/esbuild-react-docgen-typescript";
 
 const ComponentPage = ({ routes, title, code }) => {
   const MDX = React.useMemo(() => getMDXComponent(code), [code]);
@@ -43,6 +44,7 @@ export async function getStaticProps({ params }) {
     cwd: path.dirname(pathToSource),
     esbuildOptions: (options) => {
       options.plugins = [
+        esbuildReactDocgenTypescriptPlugin(),
         ...options.plugins,
         {
           name: "empty-(s)css-imports",
@@ -51,6 +53,7 @@ export async function getStaticProps({ params }) {
           },
         },
       ];
+
       return options;
     },
   });

--- a/packages/design-system/src/utils/esbuild-react-docgen-typescript.ts
+++ b/packages/design-system/src/utils/esbuild-react-docgen-typescript.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import * as docgen from "react-docgen-typescript";
+
+// This plugin expects that every comonent has stated displayName and that component name and displayName is same - otheviews no __docgenInfo will be injected
+//TODO: Make this plugin into own npm pacakge
+//FIXME: Usage of React.ComponentProps (eg. React.ComponentProps<'div'>) makes react-docgen return empty component docgen info. Import of ComponentProps (eg. ComponentProps<'div'>) fixes this issue - it's probably react-docgen-typescript issue.
+const plugin = function esbuildReactDocgenTypescriptPlugin() {
+  return {
+    name: "esbuild-react-docgen-typescript",
+    setup(build) {
+      // TODO: filter path should by a parameter of this plugin
+      const filter = /.*\/components\/src\/components\/.*\.tsx?$/;
+
+      build.onLoad({ filter }, (args) => {
+        const fileContents = fs.readFileSync(args.path, "utf8");
+
+        // Parse file for docgen info
+        const docgenInfo = docgen.parse(args.path, {
+          // filter props which comes from npm packages, because we don't want to display all props of components using for example React.ComponentProps<'div'>
+          // TODO: this could have include/exclude for more control
+          propFilter: (prop) => {
+            if (
+              prop.declarations !== undefined &&
+              prop.declarations.length > 0
+            ) {
+              const hasPropAdditionalDescription = prop.declarations.find(
+                (declaration) => {
+                  return !declaration.fileName.includes("node_modules");
+                }
+              );
+
+              return Boolean(hasPropAdditionalDescription);
+            }
+
+            return true;
+          },
+          // see react-docgen-typescript options
+          shouldExtractLiteralValuesFromEnum: true,
+          shouldExtractValuesFromUnion: true,
+        });
+
+        const docgenInfoContents = docgenInfo
+          .map((docgenInfoItem) => {
+            // react-docgen parses also files which are re-exporting components like index files and are able to get get docs there too. But since in this files components are not defined we can't inject __docgenInfo on them there. So we checking for displayName property which tell as component is defined in that file.
+            // TODO: find better heurestics to identify files with component definition
+            const hasReactComponent = fileContents.includes(
+              `${docgenInfoItem.displayName}.displayName`
+            );
+
+            // inject __docgenInfo
+            return hasReactComponent
+              ? `${docgenInfoItem.displayName}.__docgenInfo = ${JSON.stringify(
+                  docgenInfoItem
+                )};`
+              : "";
+          })
+          .join("\n");
+
+        return {
+          // add __docgenInfo at the end of the file
+          contents: fileContents + docgenInfoContents,
+          loader: "tsx",
+        };
+      });
+    },
+  };
+};
+
+export default plugin;

--- a/packages/lighter-styleguide/src/components/Props/PropsTable.tsx
+++ b/packages/lighter-styleguide/src/components/Props/PropsTable.tsx
@@ -33,7 +33,22 @@ const PropsTable = () => {
       },
       {
         Header: "Type",
-        accessor: "type.name",
+        accessor: (row) => {
+          if (row.type.raw === "boolean") {
+            return row.type.raw;
+          }
+
+          const valueString =
+            row.type.value &&
+            row.type.value.map(({ value }) => value).join(" | ");
+
+          if (valueString) {
+            return valueString;
+          }
+
+          return row.type.raw || row.type.name;
+        },
+        id: "type",
       },
       {
         Header: "Default value",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11101,6 +11101,11 @@ react-docgen-typescript@^1.15.0:
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz#00232c8e8e47f4437cac133b879b3e9437284bee"
   integrity sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==
 
+react-docgen-typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
+  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
+
 react-dom@17.0.2, react-dom@~17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"


### PR DESCRIPTION
This adds props documentation to Design system with help of `react-docgen-typescript` and custom `esbuild-react-docgen-typescript` plugin.